### PR TITLE
Fix indentation for raw block in deployment

### DIFF
--- a/charts/k8s-rocker/example.yaml
+++ b/charts/k8s-rocker/example.yaml
@@ -105,6 +105,11 @@ pod: # the main pod
     security: # supports the full security context, see https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
       privileged: true
     raw: # passed raw into the container spec
+      lifecycle:
+        preStop:
+          exec: ["/bin/sh", "-c", "sleep 10"]
+      terminationGracePeriodSeconds: 45
+
 init:
   # podspec for initing the deployment
   "foo":

--- a/charts/k8s-rocker/templates/_container.tpl
+++ b/charts/k8s-rocker/templates/_container.tpl
@@ -209,6 +209,6 @@ securityContext:
 ---- raw block
 */}}
 {{- with $container.raw }}
-{{ . | toYaml | nindent 2 }}
+{{ . | toYaml }}
 {{- end }}{{- /* end of raw */}}
 {{- end }}{{- /* end of k8s-rocker.container */}}


### PR DESCRIPTION
This fixes the wrong indent of the raw block. The alignment would have been wrong and wouldn't be correct yaml. 
Also contains an updated raw block in the example.yaml